### PR TITLE
Updat: for hugo 0.36

### DIFF
--- a/themes/hyde/layouts/partials/head.html
+++ b/themes/hyde/layouts/partials/head.html
@@ -20,5 +20,5 @@
   <link rel="shortcut icon" href="/favicon.png">
 
   <!-- RSS -->
-  <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 </head>

--- a/themes/hyde/layouts/partials/sidebar.html
+++ b/themes/hyde/layouts/partials/sidebar.html
@@ -14,6 +14,6 @@
       {{end}}
     </ul>
 
-    <p>{{ with .Site.Params.copyright }}{{.}}{{ else }}&copy; {{.Now.Format "2006"}}. All rights reserved. {{end}}</p>
+    <p>{{ with .Site.Params.copyright }}{{.}}{{ else }}&copy; {{now.Format "2006"}}. All rights reserved. {{end}}</p>
   </div>
 </div>


### PR DESCRIPTION
.Now had been deprecated replaced with the now template function in Hugo v0.20.

and .RSSlink replaced with .RSSLink